### PR TITLE
Fix redirect_uri in config example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To authenticate users that want to login at your Discourse instance will be redi
   "oauth": {
     "client_id": "theRandomIdForYourDiscourseInstance",
     "client_secret": "somethingSecure",
-    "redirect_uris": ["callbackOfYourDiscourseInstance"]
+    "redirect_uri": "https://your.discourse.instance/callback"
   }
 }
 ```


### PR DESCRIPTION
The example config was wrong, `redirect_uri` must not be called `redirect_uris`, and it must be a string.