### PR TITLE
document discourse configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,37 @@ To authenticate users that want to login at your Discourse instance will be redi
 3. Optionally configure the `http_port` (that the bot should serve the web interface on) in `config/local.js` (default: 3000).
 4. Setup a HTTP daemon to reverse-proxy the bot, e.g. nginx.
 
+### Configure Discourse
+
+First install the oauth2 plugin by adding the following line to
+`/var/discourse/containers/app.yml` and rebuilding the container:
+
+```
+          - git clone https://github.com/discourse/discourse-oauth2-basic.git
+```
+
+#### OAuth2 Settings
+
+Then new settings show up in the admin settings. These settings need to be
+configured according to your needs. On the rights, our example configuration
+for support.delta.chat/login.testrun.org:
+
+```
+oauth2 enabled: 			true
+oauth2 client id: 			secret
+oauth2 client secret: 			secret
+oauth2 authorize url:			https://login.testrun.org/oauth2/authorize
+oauth2 token url:			https://login.testrun.org/oauth2/token
+oauth2 token url method:		POST
+oauth2 callback user id path:		params.info.userid
+oauth2 callback user info paths:	name:params.info.username
+					email:params.info.email
+oauth2 fetch user details:		false
+oauth2 email verified:			true
+oauth2 button title:			with Delta Chat
+oauth2 allow association change:	true
+```
+
 ## Run
 
 Run the bot with `npm start`.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ oauth2 client secret: 			secret
 oauth2 authorize url:			https://login.testrun.org/oauth2/authorize
 oauth2 token url:			https://login.testrun.org/oauth2/token
 oauth2 token url method:		POST
-oauth2 callback user id path:		params.info.userid
+oauth2 callback user id path:		params.info.email
 oauth2 callback user info paths:	name:params.info.username
 					email:params.info.email
 oauth2 fetch user details:		false

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ To authenticate users that want to login at your Discourse instance will be redi
 ## Setup
 
 1. Install the dependencies by running `npm install`.
-2. Configure your Discourse instance to use the oauth2 provider this bot provides. Generate a random `client_id` and a random `client_secret` for it.
-2. Configure the bot by writing its email-address and password, and the oauth related information, into `config/local.json` like this:
+2. Install the [OAuth2 Plugin](https://github.com/discourse/discourse-oauth2-basic) to your Discourse instance - find out how on [meta.discourse.org](https://meta.discourse.org/t/install-plugins-in-discourse/19157)
+3. Configure your Discourse instance to use the oauth2 provider this bot provides. Choose two random strings for `client_id` and `client_secret`. More details on the Discourse settings below.
+4. Configure the bot by writing its email-address and password, and the oauth related information, into `config/local.json` like this:
 ```json
 {
   "email_address": "bot@example.net",
@@ -25,23 +26,15 @@ To authenticate users that want to login at your Discourse instance will be redi
   }
 }
 ```
-3. Optionally configure the `http_port` (that the bot should serve the web interface on) in `config/local.js` (default: 3000).
-4. Setup a HTTP daemon to reverse-proxy the bot, e.g. nginx.
+5. Optionally configure the `http_port` (that the bot should serve the web interface on) in `config/local.js` (default: 3000).
+6. Setup a HTTP daemon to reverse-proxy the bot, e.g. nginx.
 
-### Configure Discourse
+### Discourse Plugin Settings
 
-First install the oauth2 plugin by adding the following line to
-`/var/discourse/containers/app.yml` and rebuilding the container:
-
-```
-          - git clone https://github.com/discourse/discourse-oauth2-basic.git
-```
-
-#### OAuth2 Settings
-
-Then new settings show up in the admin settings. These settings need to be
-configured according to your needs. On the rights, our example configuration
-for support.delta.chat/login.testrun.org:
+After you installed the Discourse plugin in step 2, new settings show up in the
+admin settings. These settings need to be configured according to your needs.
+On the rights, our example configuration for
+support.delta.chat/login.testrun.org:
 
 ```
 oauth2 enabled: 			true


### PR DESCRIPTION
I documented more details on how to install the OAuth2 discourse plugin and configure it.

This also closes #1. 