### PR TITLE
Strip userid field from response to /token.

### DIFF
--- a/src/web_app.js
+++ b/src/web_app.js
@@ -103,7 +103,6 @@ router.get('/token', async (req, res) => {
     token_type: 'bearer',
     expires_in: 1,
     info: {
-      userid: `DeltaLoginUser${dbData.contactId}`,
       username: user.getName(),
       email: user.getAddress()
     }


### PR DESCRIPTION
The user-ID is just an incrementing integer from the database. To
deliver that as identifier to the outside weakens this bot
unnecessarily: If the incrementation is resetted (e.g.  database
crashes, is not copied on updates, ...), then the IDs suddenly reference
other contacts.
Exposing the email address as identifier to the outside avoids that.