### PR TITLE
Mark email address as verified.

### DIFF
--- a/src/web_app.js
+++ b/src/web_app.js
@@ -105,6 +105,7 @@ router.post('/token', async (req, res) => {
       userid: `DeltaLoginUser${dbData.contactId}`,
       username: user.getName(),
       email: user.getAddress()
+      email_verified: true
     }
   })
 })


### PR DESCRIPTION
One less config option that discourse admins need to set if we deliver
this information.