### PR TITLE
Apparently sending email_verified doesn't work as expected :(

### DIFF
--- a/src/web_app.js
+++ b/src/web_app.js
@@ -103,8 +103,7 @@ router.post('/token', async (req, res) => {
     expires_in: 1,
     info: {
       username: user.getName(),
-      email: user.getAddress(),
-      email_verified: true
+      email: user.getAddress()
     }
   })
 })


### PR DESCRIPTION
In discourse's settings we have to enable oauth2_email_verified
nonetheless. Then we can skip it here.